### PR TITLE
make checkpoint before making report

### DIFF
--- a/alchemie/alc.py
+++ b/alchemie/alc.py
@@ -67,14 +67,14 @@ def run(args, setup):
 
     trainer.fit()
 
+    print '>>> saving to checkpoint'
+    idx = contrib.to_checkpoint('.', trainer)
+
     print '>>> making report'
     last_pars = trainer.switch_pars(trainer.best_pars)
 
     report = setup.make_report(pars, trainer, data)
     trainer.switch_pars(last_pars)
-
-    print '>>> saving to checkpoint'
-    idx = contrib.to_checkpoint('.', trainer)
 
     fn = 'report-last.json' if trainer.stopped else 'report-%i.json' % idx
     with open(fn, 'w') as fp:


### PR DESCRIPTION
With large data sets, it can happen that a cluster kills the job before make_report is finished (in fact, it becomes likely). Thus, checkpointing is now the first action after leaving the fitting routine.
